### PR TITLE
feat(types): add LinkClass + getLinkClass display-layer classifier

### DIFF
--- a/src/core/getLinkClass.ts
+++ b/src/core/getLinkClass.ts
@@ -1,0 +1,24 @@
+// Display-layer discriminator separate from LinkObject.linkType.
+// Per §7a D3 + §7a.3 Data Shape Deltas.
+
+import type { LinkObject } from "../types/citationTypes.js";
+import type { LinkClass } from "../types/validationTypes.js";
+
+/**
+ * Classify a LinkObject for display/reporting (per D3).
+ *
+ * Rules:
+ *   linkType === "wiki"                                 → "wiki"
+ *   linkType === "markdown" && anchorType === "block"   → "caret"
+ *   linkType === "markdown"  (other anchor types)       → "markdown"
+ *
+ * Exhaustive over (linkType × anchorType): no fall-through, no undefined.
+ */
+export const getLinkClass = (link: LinkObject): LinkClass => {
+	switch (link.linkType) {
+		case "wiki":
+			return "wiki";
+		case "markdown":
+			return link.anchorType === "block" ? "caret" : "markdown";
+	}
+};

--- a/src/types/validationTypes.ts
+++ b/src/types/validationTypes.ts
@@ -10,6 +10,15 @@
 import type { LinkObject } from "./citationTypes.js";
 
 /**
+ * LinkClass - display-layer discriminator (per D3).
+ *
+ * Separate from `LinkObject.linkType` so display/reporting can distinguish
+ * caret-block markdown citations from header markdown citations without
+ * mutating the syntactic linkType field.
+ */
+export type LinkClass = "markdown" | "wiki" | "caret";
+
+/**
  * PathConversion metadata for path auto-fix suggestions
  * Used when validator detects path resolution issues
  */

--- a/test/unit/core/getLinkClass.test.ts
+++ b/test/unit/core/getLinkClass.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { getLinkClass } from "../../../src/core/getLinkClass.js";
+import type { LinkObject } from "../../../src/types/citationTypes.js";
+import type { LinkClass } from "../../../src/types/validationTypes.js";
+
+const baseLink = (
+	overrides: Partial<LinkObject> & Pick<LinkObject, "linkType" | "anchorType">,
+): LinkObject => ({
+	scope: "cross-document",
+	source: { path: { absolute: "/tmp/source.md" } },
+	target: {
+		path: { raw: "target.md", absolute: null, relative: null },
+		anchor: null,
+	},
+	text: "x",
+	fullMatch: "[x](target.md)",
+	line: 1,
+	column: 0,
+	extractionMarker: null,
+	...overrides,
+});
+
+describe("getLinkClass", () => {
+	it("returns 'wiki' for a wiki LinkObject", () => {
+		const link = baseLink({ linkType: "wiki", anchorType: null });
+		expect(getLinkClass(link)).toBe<LinkClass>("wiki");
+	});
+
+	it("returns 'caret' for markdown LinkObject with anchorType === 'block'", () => {
+		const link = baseLink({ linkType: "markdown", anchorType: "block" });
+		expect(getLinkClass(link)).toBe<LinkClass>("caret");
+	});
+
+	it("returns 'markdown' for markdown LinkObject with anchorType === 'header'", () => {
+		const link = baseLink({ linkType: "markdown", anchorType: "header" });
+		expect(getLinkClass(link)).toBe<LinkClass>("markdown");
+	});
+
+	it("returns 'markdown' for markdown LinkObject with no anchor", () => {
+		const link = baseLink({ linkType: "markdown", anchorType: null });
+		expect(getLinkClass(link)).toBe<LinkClass>("markdown");
+	});
+
+	it("maps every (linkType × anchorType) cell to exactly one LinkClass — no fall-through, no undefined", () => {
+		const linkTypes: LinkObject["linkType"][] = ["markdown", "wiki"];
+		const anchorTypes: LinkObject["anchorType"][] = ["header", "block", null];
+		const allowed: ReadonlySet<LinkClass> = new Set([
+			"markdown",
+			"wiki",
+			"caret",
+		]);
+
+		const expected: Record<string, LinkClass> = {
+			"markdown|header": "markdown",
+			"markdown|block": "caret",
+			"markdown|null": "markdown",
+			"wiki|header": "wiki",
+			"wiki|block": "wiki",
+			"wiki|null": "wiki",
+		};
+
+		for (const linkType of linkTypes) {
+			for (const anchorType of anchorTypes) {
+				const link = baseLink({ linkType, anchorType });
+				const result = getLinkClass(link);
+				expect(allowed.has(result)).toBe(true);
+				expect(result).not.toBeUndefined();
+				const key = `${linkType}|${anchorType ?? "null"}`;
+				expect(result).toBe(expected[key]);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

%% *Last Modified: 05/13/26 10:12:17* %%

- Adds `LinkClass = "markdown" | "wiki" | "caret"` type to `src/types/validationTypes.ts`
- Adds `getLinkClass(link: LinkObject): LinkClass` exhaustive classifier in `src/core/getLinkClass.ts`
- 5 unit tests covering all branches (wiki, markdown-header, markdown-block-caret, markdown-other-anchors)

## Why

%% *Last Modified: 05/13/26 10:12:17* %%

D3 display-layer discriminator. Lets reporting distinguish caret-block markdown citations (`[Text](path#anchor)` where `anchorType === "block"`) from header markdown citations without mutating the syntactic `linkType` field.

## Scope

%% *Last Modified: 05/13/26 10:12:17* %%

Additive only. No callers wired in this PR — `ValidationSummary` extension and consumer wiring will land in a later PR.

## Context

%% *Last Modified: 05/13/26 10:12:17* %%

Part 2 of the small-PR sequence extracting unique value from the closed PR #27. Part 1 was #48 (adversarial CommonMark fixtures).

## Test plan

%% *Last Modified: 05/13/26 10:12:17* %%

- [x] `npx vitest run test/unit/core/getLinkClass.test.ts` — 5/5 pass
- [x] `npm run build` — clean
- [x] Full `npm test` — no new failures (4 pre-existing `design-docs/` hardening-pipeline failures unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented new link classification system that maps links to appropriate display categories, supporting wiki links, standard markdown links, and block-level anchors.
  * Added comprehensive unit test suite covering all combinations of link types and anchor configurations to ensure consistent and correct classification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WesleyMFrederick/jact/pull/49)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->