### PR TITLE
feat(resolveWikiPath): add local-biased Levenshtein suggestion layer (Steps 3-4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.3",
-				"@types/node": "^24.10.1",
+				"@types/node": "^24.12.4",
+				"@typescript-eslint/parser": "^8.59.1",
 				"@vitest/ui": "^4.0.18",
+				"eslint": "^10.3.0",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.9.3",
 				"vitest": "^4.0.18"
@@ -654,6 +656,179 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+			"integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1081,6 +1256,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1088,14 +1270,163 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
-			"version": "24.10.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+			"version": "24.12.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+			"integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+			"integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/typescript-estree": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+			"integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.59.3",
+				"@typescript-eslint/types": "^8.59.3",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+			"integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+			"integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+			"integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+			"integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.59.3",
+				"@typescript-eslint/tsconfig-utils": "8.59.3",
+				"@typescript-eslint/types": "8.59.3",
+				"@typescript-eslint/visitor-keys": "8.59.3",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.59.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+			"integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.3",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -1244,6 +1575,16 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
 		"node_modules/acorn-walk": {
 			"version": "8.3.5",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -1255,6 +1596,23 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/arg": {
@@ -1272,6 +1630,29 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/chai": {
@@ -1297,6 +1678,46 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1359,6 +1780,161 @@
 				"@esbuild/win32-x64": "0.27.3"
 			}
 		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+			"integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.5.5",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.1",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1367,6 +1943,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/expect-type": {
@@ -1378,6 +1964,27 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
@@ -1404,6 +2011,50 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/flatted": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -1424,6 +2075,130 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/magic-string": {
@@ -1455,6 +2230,22 @@
 				"node": ">= 20"
 			}
 		},
+		"node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/mrmime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -1464,6 +2255,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1484,6 +2282,13 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1494,6 +2299,76 @@
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -1551,6 +2426,26 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.57.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -1594,6 +2489,42 @@
 				"@rollup/rollup-win32-x64-gnu": "4.57.1",
 				"@rollup/rollup-win32-x64-msvc": "4.57.1",
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/siginfo": {
@@ -1696,6 +2627,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
 		"node_modules/ts-node": {
 			"version": "10.9.2",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1740,6 +2684,19 @@
 				}
 			}
 		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1760,6 +2717,16 @@
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -1921,6 +2888,22 @@
 				}
 			}
 		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1938,6 +2921,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/yn": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1946,6 +2939,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.3",
-		"@types/node": "^24.10.1",
+		"@types/node": "^24.12.4",
 		"@typescript-eslint/parser": "^8.59.1",
 		"@vitest/ui": "^4.0.18",
 		"eslint": "^10.3.0",

--- a/src/FileCache.ts
+++ b/src/FileCache.ts
@@ -390,6 +390,36 @@ export class FileCache {
 		return result;
 	}
 
+	/**
+	 * Get entries in the shape expected by `resolveWikiPath` Levenshtein layer.
+	 *
+	 * `basename` is the filename key (matches the wiki page name to fuzzy-match against).
+	 * `relativePath` and `absolutePath` both reflect the cached absolute path — main's
+	 * FileCache does not track scope-relative form separately, but threshold ratios
+	 * clamp to ≤10 so longer absolute strings degrade gracefully.
+	 */
+	getEntries(): Array<{
+		basename: string;
+		relativePath: string;
+		absolutePath?: string;
+	}> {
+		const result: Array<{
+			basename: string;
+			relativePath: string;
+			absolutePath?: string;
+		}> = [];
+		for (const [filename, paths] of this.entries) {
+			for (const p of paths) {
+				result.push({
+					basename: filename,
+					relativePath: p,
+					absolutePath: p,
+				});
+			}
+		}
+		return result;
+	}
+
 	// Get cache statistics (total files, duplicates)
 	getCacheStats(): CacheStatsDetail {
 		const duplicates = this.duplicateNames();

--- a/src/core/MarkdownParser/resolveWikiPath.ts
+++ b/src/core/MarkdownParser/resolveWikiPath.ts
@@ -66,7 +66,7 @@ export function resolveWikiPath(
 	}
 
 	// Steps 3+4 merged: single pass over FileCache entries.
-	// Local entries (within 2 directory levels of source) get 1.5× threshold headroom;
+	// Local entries (descendants of source directory or its parent) get 1.5× threshold headroom;
 	// a local fuzzy hit returns resolved: true.
 	// Ceiling pre-filter fires before clamp() to eliminate impossible candidates cheaply.
 	const sourceDir = sourceAbsolutePath ? dirname(sourceAbsolutePath) : null;
@@ -85,6 +85,7 @@ export function resolveWikiPath(
 			SUGGESTION_THRESHOLD_CEIL,
 		);
 
+		// isLocal: descendant of source directory or its parent (2 ancestor levels from source)
 		const isLocal =
 			entry.absolutePath !== undefined &&
 			sourceDir !== null &&

--- a/src/core/MarkdownParser/resolveWikiPath.ts
+++ b/src/core/MarkdownParser/resolveWikiPath.ts
@@ -1,26 +1,58 @@
 // Per D4 (a). Sibling to resolvePath.ts. FileCache is an injected parameter (per [H-D4-factory]).
-import type { FileCache } from "../../FileCache.js";
+import { dirname } from "node:path";
+import type { ResolveResult } from "../../types/fileCacheTypes.js";
+import { levenshteinDistance } from "../../utils/stringDistance.js";
 import { pageNameToSlug } from "../../utils/wikiPageSlug.js";
 
+// Structural interface keeps the resolver decoupled from the concrete FileCache class
+// (matches DI pattern used by CitationValidator). Test stubs satisfy this without needing
+// the full FileCache surface area.
+export interface WikiPathFileCache {
+	resolveFile(filename: string): ResolveResult;
+	getEntries(): Array<{
+		basename: string;
+		relativePath: string;
+		absolutePath?: string;
+	}>;
+}
+
 // Return shape carries both attempted forms so the validator's broken-link reason
-// can list them: "tried: <raw>, <slug>.md".
+// can list them: "tried: <raw>, <slug>.md". On miss path, suggestions[] holds full
+// relative paths whose basename is within the adaptive Levenshtein threshold (per D4).
 export type ResolvedPath =
 	| { resolved: true; absolutePath: string }
-	| { resolved: false; attempted: [rawPath: string, slugPath: string] };
+	| {
+			resolved: false;
+			attempted: [rawPath: string, slugPath: string];
+			/** Full absolute paths attempted during FileCache resolution (for error output). */
+			attemptedPaths?: readonly string[];
+			suggestions: string[];
+	  };
+
+const SUGGESTION_THRESHOLD_FLOOR = 3;
+const SUGGESTION_THRESHOLD_CEIL = 10;
+const SUGGESTION_THRESHOLD_RATIO = 0.2;
+
+function clamp(value: number, lo: number, hi: number): number {
+	return Math.min(hi, Math.max(lo, value));
+}
 
 /**
- * Two-step wiki page name resolver.
+ * Wiki page name resolver with local-first fuzzy resolution.
  *
  * Step 1: fileCache.resolveFile(rawPath)              — handles already-slugged or .md forms
  * Step 2: fileCache.resolveFile(slug + ".md")         — handles Title Case / em dash page names
- * Step 3: both miss → { resolved: false, attempted: [rawPath, slugPath] }
+ * Step 3: local-biased Levenshtein — files within 2 directory levels get 1.5× threshold;
+ *         a local fuzzy hit returns resolved: true (not just a suggestion).
+ * Step 4: global Levenshtein fallback → suggestions[] only, resolved: false.
+ *         Cost optimization: scan only fires when steps 1–3 all miss.
  *
- * Levenshtein suggestion path (D4 (e)) is out of scope for this spike (ships in plan-04).
+ * Note: relative paths (./  ../) are routed via resolvePath in createLinkObject, not here.
  */
 export function resolveWikiPath(
 	rawPath: string,
-	_sourceAbsolutePath: string,
-	fileCache: FileCache,
+	sourceAbsolutePath: string,
+	fileCache: WikiPathFileCache,
 ): ResolvedPath {
 	const step1 = fileCache.resolveFile(rawPath);
 	if (step1.found) {
@@ -33,5 +65,71 @@ export function resolveWikiPath(
 		return { resolved: true, absolutePath: step2.path };
 	}
 
-	return { resolved: false, attempted: [rawPath, slugPath] };
+	// Steps 3+4 merged: single pass over FileCache entries.
+	// Local entries (within 2 directory levels of source) get 1.5× threshold headroom;
+	// a local fuzzy hit returns resolved: true.
+	// Ceiling pre-filter fires before clamp() to eliminate impossible candidates cheaply.
+	const sourceDir = sourceAbsolutePath ? dirname(sourceAbsolutePath) : null;
+	const parentDir = sourceDir ? dirname(sourceDir) : null;
+	let bestLocal: { path: string; distance: number } | null = null;
+	const candidatesWithDistance: Array<{ path: string; distance: number }> = [];
+
+	for (const entry of fileCache.getEntries()) {
+		const lenDiff = Math.abs(slugPath.length - entry.basename.length);
+		// Ceiling pre-filter: skip entries that cannot match at any threshold (max is CEIL × 1.5)
+		if (lenDiff > SUGGESTION_THRESHOLD_CEIL * 1.5) continue;
+
+		const baseThreshold = clamp(
+			Math.floor(SUGGESTION_THRESHOLD_RATIO * entry.relativePath.length),
+			SUGGESTION_THRESHOLD_FLOOR,
+			SUGGESTION_THRESHOLD_CEIL,
+		);
+
+		const isLocal =
+			entry.absolutePath !== undefined &&
+			sourceDir !== null &&
+			parentDir !== null &&
+			(entry.absolutePath.startsWith(sourceDir + "/") ||
+				entry.absolutePath.startsWith(parentDir + "/"));
+
+		const localThreshold = baseThreshold * 1.5;
+		const qualifiesForLocal = isLocal && lenDiff <= localThreshold;
+		const qualifiesForGlobal = lenDiff <= baseThreshold;
+
+		if (!qualifiesForLocal && !qualifiesForGlobal) continue;
+
+		const distance = levenshteinDistance(slugPath, entry.basename);
+
+		if (qualifiesForLocal && distance <= localThreshold && entry.absolutePath) {
+			if (!bestLocal || distance < bestLocal.distance) {
+				bestLocal = { path: entry.absolutePath, distance };
+			}
+		}
+		if (qualifiesForGlobal && distance <= baseThreshold) {
+			candidatesWithDistance.push({ path: entry.relativePath, distance });
+		}
+	}
+
+	if (bestLocal) {
+		return { resolved: true, absolutePath: bestLocal.path };
+	}
+
+	// Sort by distance (minimal changes first) and take top 3
+	const suggestions: string[] = candidatesWithDistance
+		.sort((a, b) => a.distance - b.distance)
+		.slice(0, 3)
+		.map((c) => c.path);
+
+	// Deduplicate attemptedPaths to avoid redundant paths in error output
+	const attemptedPaths: string[] = Array.from(
+		new Set([...(step1.attemptedPaths ?? []), ...(step2.attemptedPaths ?? [])]),
+	);
+	// Always include attemptedPaths for consistent error output
+	// (whether scope was explicit or auto-resolved)
+	return {
+		resolved: false,
+		attempted: [rawPath, slugPath],
+		...(attemptedPaths.length > 0 && { attemptedPaths }),
+		suggestions,
+	};
 }

--- a/src/types/fileCacheTypes.ts
+++ b/src/types/fileCacheTypes.ts
@@ -23,6 +23,7 @@ export interface ResolveResultFailure {
 	candidates?: string[]; // reason: 'duplicate' | 'duplicate_fuzzy'
 	scope?: ScopeResolution; // populated when caller built the cache via applyScope
 	nearMisses?: string[]; // reason: 'not_found'; top-3 Levenshtein ≤ 2
+	attemptedPaths?: readonly string[]; // reason: 'not_found'; full paths attempted during resolution (for error output)
 }
 
 export type ResolveResult = ResolveResultSuccess | ResolveResultFailure;

--- a/test/unit/core/MarkdownParser/resolveWikiPath.test.ts
+++ b/test/unit/core/MarkdownParser/resolveWikiPath.test.ts
@@ -7,6 +7,7 @@ const SRC_PATH = "/vault/source.md";
 // Minimal FileCache stub — exact key match only; no extension normalization
 function makeTestFileCache(entries: Record<string, string>): {
 	resolveFile(filename: string): ResolveResult;
+	getEntries(): Array<{ basename: string; relativePath: string }>;
 } {
 	return {
 		resolveFile(filename: string): ResolveResult {
@@ -19,6 +20,44 @@ function makeTestFileCache(entries: Record<string, string>): {
 				reason: "not_found",
 				message: `not found: ${filename}`,
 			};
+		},
+		// Existing tests don't exercise Levenshtein scan; return empty so suggestions=[].
+		getEntries() {
+			return [];
+		},
+	};
+}
+
+// Stub that supports D4 Levenshtein scan via getEntries() returning {basename, relativePath}.
+function makeLevTestFileCache(
+	entries: Array<{
+		basename: string;
+		relativePath: string;
+		absolutePath?: string;
+	}>,
+): {
+	resolveFile(filename: string): ResolveResult;
+	getEntries(): Array<{ basename: string; relativePath: string }>;
+} {
+	const map = new Map<string, string>();
+	for (const e of entries) {
+		if (e.absolutePath !== undefined) map.set(e.basename, e.absolutePath);
+	}
+	return {
+		resolveFile(filename: string): ResolveResult {
+			const path = map.get(filename);
+			if (path !== undefined) return { found: true, path };
+			return {
+				found: false,
+				reason: "not_found",
+				message: `not found: ${filename}`,
+			};
+		},
+		getEntries() {
+			return entries.map(({ basename, relativePath }) => ({
+				basename,
+				relativePath,
+			}));
 		},
 	};
 }
@@ -158,5 +197,142 @@ describe("resolveWikiPath — BDD: [H-D4-slug] spike acceptance gate", () => {
 				`${VAULT_BASE}/hardening-principle-open-questions-research.md`,
 			);
 		}
+	});
+});
+
+describe("resolveWikiPath — D4 Levenshtein suggestion layer (P4 — [H-D4-suggestion-threshold])", () => {
+	it("single-typo within threshold: returns single full relative path", () => {
+		// slug+".md" = "filename.md" (11), basename "filenames.md" (12), distance = 1.
+		// relativePath length = 24 → floor(0.2*24)=4 → clamp(3,10,4)=4. 1 ≤ 4 ✓
+		const cache = makeLevTestFileCache([
+			{
+				basename: "filenames.md",
+				relativePath: "wiki/files/filenames.md",
+				absolutePath: "/v/wiki/files/filenames.md",
+			},
+		]);
+		const result = resolveWikiPath("filename", SRC_PATH, cache);
+		expect(result.resolved).toBe(false);
+		if (!result.resolved) {
+			expect(result.suggestions).toEqual(["wiki/files/filenames.md"]);
+		}
+	});
+
+	it("multi-match disambiguation: returns all candidates within threshold (folder context preserved)", () => {
+		// slug+".md" = "the-hardening-principle-concept.md" (33).
+		// All basenames "the-hardening-principle.md" (26), distance 8 (insertion of "-concept").
+		// Thresholds:
+		//  wiki/concepts/.../...md    len 40 → floor(8.0)=8  → clamp 8.  8 ≤ 8 ✓
+		//  wiki/summaries/...md        len 41 → floor(8.2)=8  → clamp 8.  8 ≤ 8 ✓
+		//  raw-sources/.../...md       len 60 → floor(12)=12 → clamp 10. 8 ≤ 10 ✓
+		const cache = makeLevTestFileCache([
+			{
+				basename: "the-hardening-principle.md",
+				relativePath: "wiki/concepts/the-hardening-principle.md",
+				absolutePath: "/v/wiki/concepts/the-hardening-principle.md",
+			},
+			{
+				basename: "the-hardening-principle.md",
+				relativePath: "wiki/summaries/the-hardening-principle.md",
+			},
+			{
+				basename: "the-hardening-principle.md",
+				relativePath:
+					"raw-sources/claude-code-principles/the-hardening-principle.md",
+			},
+		]);
+		const result = resolveWikiPath(
+			"The Hardening Principle (concept)",
+			SRC_PATH,
+			cache,
+		);
+		expect(result.resolved).toBe(false);
+		if (!result.resolved) {
+			expect(result.suggestions).toHaveLength(3);
+			expect(result.suggestions).toContain(
+				"wiki/concepts/the-hardening-principle.md",
+			);
+			expect(result.suggestions).toContain(
+				"wiki/summaries/the-hardening-principle.md",
+			);
+			expect(result.suggestions).toContain(
+				"raw-sources/claude-code-principles/the-hardening-principle.md",
+			);
+		}
+	});
+
+	it("ceiling clamp (≥10): long candidate path doesn't blow up threshold", () => {
+		// relativePath length = 56 → floor(0.2*56)=11 → clamp(3,10,11)=10 (ceiling fires).
+		// slug+".md" = "abcdefghijklmn.md" (17), basename "abc.md" (6), distance = 11.
+		// 11 > 10 (ceiling) → no match. Without ceiling clamp (threshold 11) it WOULD match.
+		const cache = makeLevTestFileCache([
+			{
+				basename: "abc.md",
+				relativePath: "raw-sources/claude-code-principles/research-data/abc.md",
+				absolutePath: "/v/abc.md",
+			},
+		]);
+		const result = resolveWikiPath("abcdefghijklmn", SRC_PATH, cache);
+		expect(result.resolved).toBe(false);
+		if (!result.resolved) {
+			expect(result.suggestions).toEqual([]);
+		}
+	});
+
+	it("floor clamp (≤3): short candidate path doesn't shrink threshold below 3", () => {
+		// relativePath length = 4 → floor(0.2*4)=0 → clamp(3,10,0)=3 (floor fires).
+		// slug+".md" = "abcd.md" (7), basename "a.md" (4), distance = 3.
+		// 3 ≤ 3 → match. Without floor clamp (threshold 0), 3 > 0 → no match.
+		const cache = makeLevTestFileCache([
+			{ basename: "a.md", relativePath: "a.md", absolutePath: "/v/a.md" },
+		]);
+		const result = resolveWikiPath("abcd", SRC_PATH, cache);
+		expect(result.resolved).toBe(false);
+		if (!result.resolved) {
+			expect(result.suggestions).toEqual(["a.md"]);
+		}
+	});
+
+	it("no-match: returns empty suggestions array (no false-positive)", () => {
+		// Distance way exceeds threshold for any candidate.
+		const cache = makeLevTestFileCache([
+			{
+				basename: "completely-different-name.md",
+				relativePath: "wiki/x/completely-different-name.md",
+				absolutePath: "/v/cdn.md",
+			},
+		]);
+		const result = resolveWikiPath("xyz", SRC_PATH, cache);
+		expect(result.resolved).toBe(false);
+		if (!result.resolved) {
+			expect(result.suggestions).toEqual([]);
+		}
+	});
+
+	it("hit-path: Levenshtein scan NOT invoked (cost optimization — fires only on miss)", () => {
+		let getEntriesCalls = 0;
+		const cache = {
+			resolveFile(filename: string): ResolveResult {
+				if (filename === "the-hardening-principle.md") {
+					return {
+						found: true,
+						path: "/v/the-hardening-principle.md",
+					};
+				}
+				return {
+					found: false,
+					reason: "not_found" as const,
+					message: "x",
+				};
+			},
+			getEntries() {
+				getEntriesCalls++;
+				return [];
+			},
+		};
+		// Step-1 raw="the-hardening-principle" misses; Step-2 slug "the-hardening-principle.md" hits.
+		const result = resolveWikiPath("the-hardening-principle", SRC_PATH, cache);
+		expect(result.resolved).toBe(true);
+		expect(getEntriesCalls).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

%% *Last Modified: 05/13/26 10:27:29* %%

Extends `resolveWikiPath` beyond exact + slug match (Steps 1–2) with a local-biased Levenshtein suggestion layer (Steps 3–4):

- **Step 3** — local-biased fuzzy match. Files within 2 directory levels of the source get 1.5× threshold headroom; a local fuzzy hit returns `resolved: true` (not just a suggestion).
- **Step 4** — global Levenshtein fallback → `suggestions[]` only, `resolved: false`.

Adaptive threshold: `clamp(0.2 × pathLen, floor=3, ceil=10)`. Ceiling pre-filter eliminates impossible candidates before invoking the DP.

## Why

%% *Last Modified: 05/13/26 10:27:29* %%

Today, a misspelled wikilink like `[[architecure]]` returns "not found" with no recovery hint. With this PR, the validator can suggest `[[architecture]]` and even auto-resolve when the match is unambiguous and local.

## Supporting changes

%% *Last Modified: 05/13/26 10:27:29* %%

- `FileCache.getEntries()` — shim exposing entries as `{basename, relativePath, absolutePath}`. No new state; derived from existing `entries` map.
- `ResolveResultFailure.attemptedPaths?: readonly string[]` — optional field for error output, populated when the resolver wants to show what it tried.
- `WikiPathFileCache` structural interface — decouples resolver from the concrete `FileCache` class (matches DI pattern used by `CitationValidator`).

## Test plan

%% *Last Modified: 05/13/26 10:27:29* %%

- [x] `npx vitest run test/unit/core/MarkdownParser/resolveWikiPath.test.ts` — 15/15 pass
- [x] `npm run build` — clean
- [x] Full `npm test` — no new failures (same 4 pre-existing `design-docs/` hardening-pipeline failures)

## Context

%% *Last Modified: 05/13/26 10:27:29* %%

Part 3 of the small-PR sequence extracting unique value from the closed PR #27. Previous: #48 (adversarial fixtures), #49 (`getLinkClass`). Next: PR-D (`.gitignore`-aware FileCache scan + `--allow-gitignore` flag).

## Behavioral note

%% *Last Modified: 05/13/26 10:27:29* %%

Main's `FileCache` stores absolute paths only (no scope-relative form). The `getEntries()` shim sets both `relativePath` and `absolutePath` to the cached absolute path. Threshold ratio (0.2 × pathLen) will run higher than the original branch design for deeply nested scopes, but clamps to `ceil=10` so behavior degrades gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fuzzy, local‑biased wiki path matching with ranked suggestions for near matches.

* **Improvements**
  * Enhanced resolution diagnostics now include attempted paths and explicit suggestion lists.
  * Suggestion results respect directory context and ranking thresholds.

* **Tests**
  * New unit tests covering fuzzy suggestion behavior and non‑invasive exact-match performance.

* **Chores**
  * Development dependency version bumped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WesleyMFrederick/jact/pull/50)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->