### PR TITLE
feat(FileCache): gitignore-aware scope scan + --allow-gitignore CLI flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"commander": "^14.0.1",
+				"ignore": "^7.0.5",
 				"marked": "^17.0.1"
 			},
 			"bin": {
@@ -1881,6 +1882,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/espree": {
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -2091,10 +2102,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"commander": "^14.0.1",
+		"ignore": "^7.0.5",
 		"marked": "^17.0.1"
 	},
 	"devDependencies": {

--- a/src/FileCache.ts
+++ b/src/FileCache.ts
@@ -154,14 +154,15 @@ export class FileCache {
 	 *
 	 * Always includes DEFAULT_SCAN_IGNORE_PATTERNS. When `respectGitignore` is
 	 * true and the scope root has a readable `.gitignore`, its patterns are
-	 * appended. Missing or unreadable `.gitignore` is non-fatal — defaults still
-	 * apply.
+	 * loaded first, then DEFAULT_SCAN_IGNORE_PATTERNS are added to ensure
+	 * defaults are authoritative (cannot be negated by .gitignore).
+	 * Missing or unreadable `.gitignore` is non-fatal — defaults still apply.
 	 */
 	private buildIgnoreRules(
 		scanRoot: string,
 		respectGitignore: boolean,
 	): Ignore {
-		const rules = ignore().add([...DEFAULT_SCAN_IGNORE_PATTERNS]);
+		const rules = ignore();
 		if (respectGitignore) {
 			const gitignorePath = this.path.join(scanRoot, ".gitignore");
 			try {
@@ -171,6 +172,7 @@ export class FileCache {
 				// No .gitignore or unreadable — defaults still apply.
 			}
 		}
+		rules.add([...DEFAULT_SCAN_IGNORE_PATTERNS]);
 		return rules;
 	}
 

--- a/src/FileCache.ts
+++ b/src/FileCache.ts
@@ -1,6 +1,24 @@
+import ignore, { type Ignore } from "ignore";
 import type { ScopeResolution } from "./core/resolveScope.js";
 import type { CacheStats, ResolveResult } from "./types/fileCacheTypes.js";
 import { levenshteinDistance } from "./utils/stringDistance.js";
+
+/**
+ * Default ignore patterns applied to every scan regardless of `.gitignore`
+ * presence. Keeps the cache from indexing VCS metadata, vendored deps, and
+ * build output that are never meaningful as wikilink targets.
+ */
+const DEFAULT_SCAN_IGNORE_PATTERNS: readonly string[] = [
+	".git/",
+	".hg/",
+	".svn/",
+	".venv/",
+	"venv/",
+	"node_modules/",
+	"dist/",
+	"build/",
+	"coverage/",
+];
 
 interface FileEntry {
 	filename: string;
@@ -64,15 +82,23 @@ export class FileCache {
 	 * Scans all subdirectories for .md files and indexes by filename. Warns if duplicate
 	 * filenames are detected (these will require relative path disambiguation).
 	 *
+	 * Filtering: DEFAULT_SCAN_IGNORE_PATTERNS always apply. When
+	 * `options.respectGitignore` is true (default), the root `.gitignore` is also
+	 * loaded and applied. Pass `respectGitignore: false` to disable `.gitignore`
+	 * filtering (default patterns still apply).
+	 *
 	 * @param scopeFolder - Root folder to scan (can be symlink, will be resolved)
 	 * @param verbose - When true, log duplicate filename warnings to stderr
 	 * @param scope - Optional resolution metadata used by resolveFile to enrich error messages
+	 * @param options - Scan options
+	 * @param options.respectGitignore - When true (default), apply root .gitignore patterns during scan
 	 * @returns Cache statistics with { totalFiles, duplicates, scopeFolder, realScopeFolder }
 	 */
 	buildCache(
 		scopeFolder: string,
 		verbose = false,
 		scope?: ScopeResolution,
+		options: { respectGitignore?: boolean } = {},
 	): CacheStats {
 		this.entries.clear();
 		this.scope = scope;
@@ -86,7 +112,13 @@ export class FileCache {
 			targetScanFolder = absoluteScopeFolder;
 		}
 
-		this.scanDirectory(targetScanFolder);
+		const respectGitignore = options.respectGitignore !== false;
+		const ignoreRules = this.buildIgnoreRules(
+			targetScanFolder,
+			respectGitignore,
+		);
+
+		this.scanDirectory(targetScanFolder, targetScanFolder, ignoreRules);
 
 		const dupNames = this.duplicateNames();
 
@@ -117,16 +149,53 @@ export class FileCache {
 		return dups;
 	}
 
-	private scanDirectory(dirPath: string): void {
+	/**
+	 * Build the Ignore rules object used to filter entries during scan.
+	 *
+	 * Always includes DEFAULT_SCAN_IGNORE_PATTERNS. When `respectGitignore` is
+	 * true and the scope root has a readable `.gitignore`, its patterns are
+	 * appended. Missing or unreadable `.gitignore` is non-fatal — defaults still
+	 * apply.
+	 */
+	private buildIgnoreRules(
+		scanRoot: string,
+		respectGitignore: boolean,
+	): Ignore {
+		const rules = ignore().add([...DEFAULT_SCAN_IGNORE_PATTERNS]);
+		if (respectGitignore) {
+			const gitignorePath = this.path.join(scanRoot, ".gitignore");
+			try {
+				const content = this.fs.readFileSync(gitignorePath, "utf-8");
+				rules.add(content);
+			} catch (_error) {
+				// No .gitignore or unreadable — defaults still apply.
+			}
+		}
+		return rules;
+	}
+
+	private scanDirectory(
+		dirPath: string,
+		scanRoot: string,
+		ignoreRules: Ignore,
+	): void {
 		try {
 			const entries = this.fs.readdirSync(dirPath);
 
 			for (const entry of entries) {
 				const fullPath = this.path.join(dirPath, entry);
 				const stat = this.fs.statSync(fullPath);
+				const isDir = stat.isDirectory();
+				// `ignore` lib expects POSIX-style paths relative to scanRoot;
+				// directory entries must end with "/" to match dir-only patterns.
+				const relative = this.path.relative(scanRoot, fullPath);
+				if (relative === "") continue;
+				const posixRelative = relative.split(this.path.sep).join("/");
+				const testPath = isDir ? `${posixRelative}/` : posixRelative;
+				if (ignoreRules.ignores(testPath)) continue;
 
-				if (stat.isDirectory()) {
-					this.scanDirectory(fullPath);
+				if (isDir) {
+					this.scanDirectory(fullPath, scanRoot, ignoreRules);
 				} else if (entry.endsWith(".md")) {
 					this.addToCache(entry, fullPath);
 				}

--- a/src/core/MarkdownParser/resolveWikiPath.ts
+++ b/src/core/MarkdownParser/resolveWikiPath.ts
@@ -54,6 +54,7 @@ function clamp(value: number, lo: number, hi: number): number {
  * @param sourceAbsolutePath - Absolute path of the source file used to prefer nearby files when fuzzy matching; may be empty.
  * @param fileCache - Cache providing file resolution and entries for fuzzy matching.
  * @returns A ResolvedPath: on success includes `{ resolved: true; absolutePath }`; on failure includes `attempted` (the raw and slugged forms), optional `attemptedPaths` (deduplicated looked-up paths), and `suggestions` (up to three ranked relative paths).
+ */
 export function resolveWikiPath(
 	rawPath: string,
 	sourceAbsolutePath: string,

--- a/src/jact.ts
+++ b/src/jact.ts
@@ -252,9 +252,12 @@ export class JactCli {
 
 			// Build file cache if scope is provided
 			if (options.scope) {
+				const respectGitignore = !options.allowGitignore;
 				const cacheStats = this.fileCache.buildCache(
 					options.scope,
 					options.verbose ?? false,
+					undefined,
+					{ respectGitignore },
 				);
 				// Only show cache messages in verbose, non-JSON mode
 				if (options.verbose && options.format !== "json") {
@@ -917,7 +920,13 @@ export class JactCli {
 
 			// Build file cache if scope is provided
 			if (options.scope) {
-				const cacheStats = this.fileCache.buildCache(options.scope);
+				const respectGitignore = !options.allowGitignore;
+				const cacheStats = this.fileCache.buildCache(
+					options.scope,
+					false,
+					undefined,
+					{ respectGitignore },
+				);
 				console.log(
 					`Scanned ${cacheStats.totalFiles} files in ${cacheStats.scopeFolder}`,
 				);

--- a/src/jact.ts
+++ b/src/jact.ts
@@ -68,6 +68,7 @@ interface CliValidateOptions {
 	format?: string;
 	fix?: boolean;
 	verbose?: boolean;
+	allowGitignore?: boolean;
 }
 
 // D-003: CliExtractOptions imported from ./types/contentExtractorTypes.js (canonical type)
@@ -147,7 +148,10 @@ export class JactCli {
 	 * builds the file cache against the resolved root. Throws when scope
 	 * cannot be inferred so callers don't silently fall back to no-scope mode.
 	 */
-	private applyScope(options: { scope?: string }, targetFile?: string): void {
+	private applyScope(
+		options: { scope?: string; allowGitignore?: boolean },
+		targetFile?: string,
+	): void {
 		const resolved = resolveScope({
 			...(options.scope !== undefined && { explicit: options.scope }),
 			cwd: process.cwd(),
@@ -159,7 +163,11 @@ export class JactCli {
 				`cannot resolve scope. Tried: ${triedParts.join(", ")}. Pass --scope <dir>.`,
 			);
 		}
-		this.fileCache.buildCache(resolved.scope, false, resolved);
+		// Default: respect `.gitignore`. `--allow-gitignore` opts in to scanning
+		// files that `.gitignore` excludes.
+		this.fileCache.buildCache(resolved.scope, false, resolved, {
+			respectGitignore: !options.allowGitignore,
+		});
 	}
 
 	/**
@@ -1238,6 +1246,11 @@ program
 	.option(
 		"--verbose",
 		"show full validation report: all valid citations, duplicate-filename warnings, summary block (default: minimal output with only errors/warnings)",
+		false,
+	)
+	.option(
+		"--allow-gitignore",
+		"include files that .gitignore would normally exclude in the scope scan (default: respect .gitignore)",
 		false,
 	)
 	.addHelpText(

--- a/test/hardening-pipeline/c1-d1-injectable-bans.test.ts
+++ b/test/hardening-pipeline/c1-d1-injectable-bans.test.ts
@@ -7,7 +7,7 @@
 //   (b) test/idiom-guards.test.ts does not exist → vitest cannot find it.
 //   (c) PostToolUse hook entry does not exist in ~/.claude/settings.json.
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -26,7 +26,7 @@ describe("C1 — D1 named-array ESLint + vitest idiom-guard library", () => {
 		expect(existsSync(ESLINT_CONFIG), "eslint.config.js missing").toBe(true);
 		let exitCode = 0;
 		try {
-			execSync(`npx eslint ${FIXTURE}`, { cwd: REPO_ROOT, stdio: "pipe" });
+			execFileSync("npx", ["eslint", FIXTURE], { cwd: REPO_ROOT, stdio: "pipe" });
 		} catch (err) {
 			exitCode = (err as { status?: number }).status ?? 1;
 		}
@@ -39,7 +39,7 @@ describe("C1 — D1 named-array ESLint + vitest idiom-guard library", () => {
 		);
 		let exitCode = 0;
 		try {
-			execSync(`npx vitest run ${IDIOM_GUARD}`, {
+			execFileSync("npx", ["vitest", "run", IDIOM_GUARD], {
 				cwd: REPO_ROOT,
 				stdio: "pipe",
 			});

--- a/test/hardening-pipeline/c1-d1-injectable-bans.test.ts
+++ b/test/hardening-pipeline/c1-d1-injectable-bans.test.ts
@@ -26,7 +26,7 @@ describe("C1 — D1 named-array ESLint + vitest idiom-guard library", () => {
 		expect(existsSync(ESLINT_CONFIG), "eslint.config.js missing").toBe(true);
 		let exitCode = 0;
 		try {
-			execSync(`bun eslint ${FIXTURE}`, { cwd: REPO_ROOT, stdio: "pipe" });
+			execSync(`npx eslint ${FIXTURE}`, { cwd: REPO_ROOT, stdio: "pipe" });
 		} catch (err) {
 			exitCode = (err as { status?: number }).status ?? 1;
 		}
@@ -39,7 +39,7 @@ describe("C1 — D1 named-array ESLint + vitest idiom-guard library", () => {
 		);
 		let exitCode = 0;
 		try {
-			execSync(`bun vitest run ${IDIOM_GUARD}`, {
+			execSync(`npx vitest run ${IDIOM_GUARD}`, {
 				cwd: REPO_ROOT,
 				stdio: "pipe",
 			});

--- a/test/unit/FileCache.gitignore.test.ts
+++ b/test/unit/FileCache.gitignore.test.ts
@@ -111,4 +111,16 @@ describe("FileCache — .gitignore respect", () => {
 		const stats = cache.buildCache(tmpDir);
 		expect(stats.totalFiles).toBe(1);
 	});
+
+	it("gitignore negation patterns cannot override DEFAULT_SCAN_IGNORE_PATTERNS", () => {
+		// Attempt to re-include node_modules/ via negation pattern
+		writeFile(".gitignore", "!node_modules/\n");
+		writeFile("public.md");
+		writeFile("node_modules/some-pkg/readme.md");
+		const stats = cache.buildCache(tmpDir);
+		// node_modules/ should still be excluded (default patterns are authoritative)
+		expect(stats.totalFiles).toBe(1);
+		expect(cache.resolveFile("public.md").found).toBe(true);
+		expect(cache.resolveFile("readme.md").found).toBe(false);
+	});
 });

--- a/test/unit/FileCache.gitignore.test.ts
+++ b/test/unit/FileCache.gitignore.test.ts
@@ -1,0 +1,114 @@
+/**
+ * FileCache .gitignore-aware scan tests.
+ *
+ * Verifies:
+ *   - DEFAULT_SCAN_IGNORE_PATTERNS always apply (.git/, node_modules/, dist/, etc.)
+ *   - Root .gitignore is respected when respectGitignore is true (default)
+ *   - respectGitignore: false skips .gitignore but still applies defaults
+ *   - Missing .gitignore is non-fatal; defaults still apply
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FileCache } from "../../src/FileCache.js";
+
+let tmpDir: string;
+let cache: FileCache;
+
+beforeEach(() => {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "filecache-gitignore-"));
+	tmpDir = fs.realpathSync(tmp);
+	cache = new FileCache(fs, path);
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(relPath: string, content = "# Test"): void {
+	const fullPath = path.join(tmpDir, relPath);
+	fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+	fs.writeFileSync(fullPath, content);
+}
+
+describe("FileCache — default ignore patterns", () => {
+	it("excludes node_modules/ by default", () => {
+		writeFile("alpha.md");
+		writeFile("node_modules/some-pkg/readme.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+		expect(cache.resolveFile("alpha.md").found).toBe(true);
+		expect(cache.resolveFile("readme.md").found).toBe(false);
+	});
+
+	it("excludes .git/ by default", () => {
+		writeFile("alpha.md");
+		writeFile(".git/HEAD.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+	});
+
+	it("excludes dist/ and build/ by default", () => {
+		writeFile("alpha.md");
+		writeFile("dist/output.md");
+		writeFile("build/artifact.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+	});
+
+	it("defaults still apply when respectGitignore is false", () => {
+		writeFile("alpha.md");
+		writeFile("node_modules/some-pkg/readme.md");
+		const stats = cache.buildCache(tmpDir, false, undefined, {
+			respectGitignore: false,
+		});
+		expect(stats.totalFiles).toBe(1);
+	});
+});
+
+describe("FileCache — .gitignore respect", () => {
+	it("respects root .gitignore by default", () => {
+		writeFile(".gitignore", "secret.md\n");
+		writeFile("public.md");
+		writeFile("secret.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+		expect(cache.resolveFile("public.md").found).toBe(true);
+		expect(cache.resolveFile("secret.md").found).toBe(false);
+	});
+
+	it("respects directory patterns in .gitignore", () => {
+		writeFile(".gitignore", "private/\n");
+		writeFile("public.md");
+		writeFile("private/notes.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+	});
+
+	it("respects glob patterns in .gitignore", () => {
+		writeFile(".gitignore", "*.draft.md\n");
+		writeFile("final.md");
+		writeFile("article.draft.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+		expect(cache.resolveFile("final.md").found).toBe(true);
+	});
+
+	it("respectGitignore: false includes .gitignore-excluded files", () => {
+		writeFile(".gitignore", "secret.md\n");
+		writeFile("public.md");
+		writeFile("secret.md");
+		const stats = cache.buildCache(tmpDir, false, undefined, {
+			respectGitignore: false,
+		});
+		expect(stats.totalFiles).toBe(2);
+		expect(cache.resolveFile("secret.md").found).toBe(true);
+	});
+
+	it("missing .gitignore is non-fatal", () => {
+		writeFile("alpha.md");
+		const stats = cache.buildCache(tmpDir);
+		expect(stats.totalFiles).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

%% *Last Modified: 05/13/26 11:22:06* %%

`FileCache` now applies a ruleset during scope scan to skip directories and files that shouldn't be indexed as wikilink targets.

- **`DEFAULT_SCAN_IGNORE_PATTERNS`** always apply: `.git/`, `.hg/`, `.svn/`, `.venv/`, `venv/`, `node_modules/`, `dist/`, `build/`, `coverage/`
- **`.gitignore` respected by default** — the root `.gitignore` is loaded and its patterns are appended to the ruleset
- **Missing `.gitignore` is non-fatal** — defaults still apply
- Uses the [`ignore`](https://www.npmjs.com/package/ignore) npm package (gitignore-spec compliant)

## CLI

%% *Last Modified: 05/13/26 11:22:06* %%

```
jact validate <file>                    # respects .gitignore (default)
jact validate <file> --allow-gitignore  # scans files .gitignore would exclude
                                        # (defaults like .git/ still apply)
```

## Why

%% *Last Modified: 05/13/26 11:22:06* %%

Today, `FileCache` scans every `.md` file under the scope folder. For Obsidian vaults that share a repo with code, this means `node_modules/` README files and dist artifacts pollute the cache. For private vaults that explicitly `.gitignore` draft notes, the cache leaks them into resolution results. This PR teaches the cache to honor the project's existing exclusion conventions.

## Drive-by

%% *Last Modified: 05/13/26 11:22:06* %%

Fixes an unterminated docstring in `resolveWikiPath.ts` left by #51 — `tsc` was failing on `main`.

## Test plan

%% *Last Modified: 05/13/26 11:22:06* %%

- [x] `npx vitest run test/unit/FileCache.gitignore.test.ts` — 9/9 pass (default patterns, `.gitignore` file/dir/glob respect, opt-out, missing-file safety)
- [x] `npm run build` — clean
- [x] Full `npm test` — same 4 pre-existing `design-docs/` hardening-pipeline failures; no new failures

## Context

%% *Last Modified: 05/13/26 11:22:06* %%

Part 4 / final of the small-PR sequence extracting unique value from the closed PR #27. Previous: #48 (adversarial fixtures), #49 (`getLinkClass`), #50 (Levenshtein layer).

## Scope notes

%% *Last Modified: 05/13/26 11:22:06* %%

- Only the `validate` command exposes `--allow-gitignore` so far. Other commands (`ast`, `links`, `header`, `file`, `extract`) inherit gitignore-respecting behavior via shared `applyScope`. The flag can be added to other commands in a follow-up if needed.
- Adds runtime dep `ignore@^7.0.5` (no peer deps, ~10kB minified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File scanning now respects .gitignore patterns by default while retaining authoritative default ignores.
  * Added --allow-gitignore CLI flag to optionally include files normally excluded by .gitignore.

* **Tests**
  * Added unit tests covering .gitignore-aware scanning, default ignore enforcement, and negation handling.

* **Chores**
  * Added a runtime dependency for ignore-pattern handling.
  * CI/test helper updated to invoke tooling via npx.

* **Documentation**
  * Minor comment/JSDoc closure fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WesleyMFrederick/jact/pull/52)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->