### PR TITLE
refactor(types): consolidate CliValidateOptions (closes #34)

### DIFF
--- a/src/jact.ts
+++ b/src/jact.ts
@@ -50,6 +50,7 @@ import type { ParsedFileCache } from "./ParsedFileCache.js";
 import type { ParserOutput } from "./types/citationTypes.js";
 import type {
 	CliExtractOptions,
+	CliValidateOptions,
 	OutgoingLinksExtractedContent,
 } from "./types/contentExtractorTypes.js";
 import type {
@@ -60,19 +61,7 @@ import type {
 
 const CACHE_DIR = ".jact/claude-cache";
 
-/**
- * Options for validation operations.
- */
-interface CliValidateOptions {
-	scope?: string;
-	lines?: string;
-	format?: string;
-	fix?: boolean;
-	verbose?: boolean;
-	allowGitignore?: boolean;
-}
-
-// D-003: CliExtractOptions imported from ./types/contentExtractorTypes.js (canonical type)
+// D-003: CliExtractOptions and CliValidateOptions imported from ./types/contentExtractorTypes.js (canonical types)
 
 /**
  * Line range parsed from input string.

--- a/src/types/contentExtractorTypes.ts
+++ b/src/types/contentExtractorTypes.ts
@@ -113,6 +113,8 @@ export interface CliValidateOptions {
 	lines?: string;
 	scope?: string;
 	fix?: boolean;
+	verbose?: boolean;
+	allowGitignore?: boolean;
 }
 
 /**

--- a/test/unit/types/cliTypes.test.ts
+++ b/test/unit/types/cliTypes.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import type {
-	CliValidateOptions,
 	CliExtractOptions,
-	FormattedValidationResult,
+	CliValidateOptions,
 	FixDetail,
+	FormattedValidationResult,
 } from "../../../src/types/contentExtractorTypes.js";
 
 describe("CLI Types", () => {
@@ -13,8 +13,12 @@ describe("CLI Types", () => {
 			lines: "150-160",
 			scope: "/docs",
 			fix: true,
+			verbose: true,
+			allowGitignore: false,
 		};
 		expect(opts.format).toBe("json");
+		expect(opts.verbose).toBe(true);
+		expect(opts.allowGitignore).toBe(false);
 	});
 
 	it("CliValidateOptions allows empty object", () => {


### PR DESCRIPTION
## Summary
- Delete local `CliValidateOptions` shadow from `src/jact.ts` (had `format?: string` — widened regression)
- Expand canonical in `src/types/contentExtractorTypes.ts` with `verbose?: boolean` + `allowGitignore?: boolean`
- Import canonical type in `src/jact.ts`
- Add test assertions for new fields in `test/unit/types/cliTypes.test.ts`

Closes #34. Same pattern as #32 (already closed).

## Test plan
- [x] `npm run build` clean (`tsc` zero errors)
- [x] `npm test` — all CliValidateOptions assertions pass; 6 pre-existing failures unrelated (c6-fixture-template, ast-default-scope scenarios 7+9)
- [x] All 4 call sites in `jact.ts` compile against the canonical type
- [x] `format` confirmed narrowed to `"cli" | "json"` (was already correct in canonical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)