### PR TITLE
refactor(types): move HeaderObject and FixRecord to validationTypes (closes #36)

### DIFF
--- a/src/jact.ts
+++ b/src/jact.ts
@@ -55,6 +55,8 @@ import type {
 } from "./types/contentExtractorTypes.js";
 import type {
 	EnrichedLinkObject,
+	FixRecord,
+	HeaderObject,
 	PathConversion,
 	ValidationResult,
 } from "./types/validationTypes.js";
@@ -69,24 +71,6 @@ const CACHE_DIR = ".jact/claude-cache";
 interface LineRange {
 	startLine: number;
 	endLine: number;
-}
-
-/**
- * Header object with text and anchor.
- */
-interface HeaderObject {
-	text: string;
-	anchor: string;
-}
-
-/**
- * Fix record tracking applied fixes.
- */
-interface FixRecord {
-	line: number;
-	old: string;
-	new: string;
-	type: string;
 }
 
 /**

--- a/src/types/validationTypes.ts
+++ b/src/types/validationTypes.ts
@@ -80,3 +80,21 @@ export interface ValidationResult {
 	links: EnrichedLinkObject[];
 	validationTime?: string;
 }
+
+/**
+ * Header object with text and anchor.
+ */
+export interface HeaderObject {
+	text: string;
+	anchor: string;
+}
+
+/**
+ * Fix record tracking applied fixes.
+ */
+export interface FixRecord {
+	line: number;
+	old: string;
+	new: string;
+	type: string;
+}


### PR DESCRIPTION
## Summary

- Moves `HeaderObject` and `FixRecord` out of `src/jact.ts` (CLI orchestrator) into `src/types/validationTypes.ts`
- Updates `src/jact.ts` to import both types from `./types/validationTypes.js`
- No local duplicate declarations remain in `jact.ts`

## Test plan

- [x] `npm run build` — no TypeScript errors
- [x] `npm test` — same 6 pre-existing failures (unrelated to this change), 612 pass
- [x] AC verified: interfaces deleted from jact.ts, added to validationTypes.ts, imported correctly, no duplicates

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type definitions have been reorganized and centralized for improved code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WesleyMFrederick/jact/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->