### PR TITLE
chore(scripts): add check script that runs type-check then test in sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:ui": "vitest --ui",
 		"test:coverage": "vitest run --coverage",
 		"type-check": "tsc --noEmit",
+		"check": "npm run type-check && npm test",
 		"start": "node dist/jact.js",
 		"validate:ts-conversion": "node --loader ts-node/esm scripts/validate-typescript-conversion.ts",
 		"jact:validate": "node ./dist/jact.js validate",


### PR DESCRIPTION
## Summary

- Adds a `check` script to `package.json` that runs `npm run type-check && npm test` in sequence
- Enforces the type-check → test ordering as a single command, satisfying testing principles §Test Quality Gates and Maintenance
- No source code changes; package.json scripts only

## Acceptance Criteria

- [x] `check` script added to `package.json`
- [x] Script runs `type-check` first, then `test` in sequence
- [x] Build passes (`npm run build`)
- [x] Existing tests pass (pre-existing 4 failures in `hardening-pipeline` are unrelated to this change)

## Definition of Done

- [x] `npm run check` executes `tsc --noEmit` then `vitest run` in order
- [x] Committed and pushed on feature branch

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)