### PR TITLE
test(audit): fix beforeEach input-construction violations (closes #60)

### DIFF
--- a/test/cache/checkExtractCache.test.ts
+++ b/test/cache/checkExtractCache.test.ts
@@ -7,6 +7,8 @@ import {
 	writeExtractCache,
 } from "../../src/cache/checkExtractCache.js";
 
+const TEST_FILE_CONTENT = "# Test\n\nSome content with [[links]]";
+
 describe("checkExtractCache", () => {
 	let testDir: string;
 	let cacheDir: string;
@@ -20,7 +22,6 @@ describe("checkExtractCache", () => {
 		cacheDir = join(testDir, "claude-cache");
 		mkdirSync(testDir, { recursive: true });
 		testFile = join(testDir, "test.md");
-		writeFileSync(testFile, "# Test\n\nSome content with [[links]]");
 	});
 
 	afterEach(() => {
@@ -28,12 +29,14 @@ describe("checkExtractCache", () => {
 	});
 
 	it("returns false when no marker file exists (cache miss)", () => {
+		writeFileSync(testFile, TEST_FILE_CONTENT);
 		mkdirSync(cacheDir, { recursive: true });
 		const result = checkExtractCache("session-abc", testFile, cacheDir);
 		expect(result).toBe(false);
 	});
 
 	it("returns true after writeExtractCache creates marker (cache hit)", () => {
+		writeFileSync(testFile, TEST_FILE_CONTENT);
 		mkdirSync(cacheDir, { recursive: true });
 		writeExtractCache("session-abc", testFile, cacheDir);
 		const result = checkExtractCache("session-abc", testFile, cacheDir);
@@ -41,6 +44,7 @@ describe("checkExtractCache", () => {
 	});
 
 	it("returns false when file content changes (invalidation)", () => {
+		writeFileSync(testFile, TEST_FILE_CONTENT);
 		mkdirSync(cacheDir, { recursive: true });
 		writeExtractCache("session-abc", testFile, cacheDir);
 
@@ -52,6 +56,7 @@ describe("checkExtractCache", () => {
 	});
 
 	it("works when cache directory does not exist yet (auto-creation)", () => {
+		writeFileSync(testFile, TEST_FILE_CONTENT);
 		// cacheDir not created — functions should auto-create
 		const result = checkExtractCache("session-abc", testFile, cacheDir);
 		expect(result).toBe(false);

--- a/test/cli-integration/extract-header-format.test.ts
+++ b/test/cli-integration/extract-header-format.test.ts
@@ -6,6 +6,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const CLI_PATH = join(__dirname, "../../dist/jact.js");
 
+const SOURCE_MD_CONTENT =
+	"# Doc\n\n## Overview\n\nThis is the overview content.\n\nWith multiple lines.\n\n## Other\n\nUnrelated section.\n";
+
 /**
  * D-001: extract header default output format changed from JSON to markdown.
  * Verifies --format flag behavior and default output.
@@ -19,11 +22,6 @@ describe("extract header --format flag", () => {
 			`format-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 		);
 		mkdirSync(testDir, { recursive: true });
-
-		writeFileSync(
-			join(testDir, "source.md"),
-			"# Doc\n\n## Overview\n\nThis is the overview content.\n\nWith multiple lines.\n\n## Other\n\nUnrelated section.\n",
-		);
 	});
 
 	afterEach(() => {
@@ -31,6 +29,7 @@ describe("extract header --format flag", () => {
 	});
 
 	it("default output (no --format flag) is raw markdown, NOT JSON", () => {
+		writeFileSync(join(testDir, "source.md"), SOURCE_MD_CONTENT);
 		const output = execSync(
 			`node "${CLI_PATH}" extract header "${join(testDir, "source.md")}" "Overview" --scope "${testDir}"`,
 			{ encoding: "utf8" },
@@ -43,6 +42,7 @@ describe("extract header --format flag", () => {
 	});
 
 	it("--format json returns valid JSON with OutgoingLinksExtractedContent structure", () => {
+		writeFileSync(join(testDir, "source.md"), SOURCE_MD_CONTENT);
 		const output = execSync(
 			`node "${CLI_PATH}" extract header "${join(testDir, "source.md")}" "Overview" --scope "${testDir}" --format json --verbose`,
 			{ encoding: "utf8" },
@@ -58,6 +58,7 @@ describe("extract header --format flag", () => {
 	});
 
 	it("--format markdown explicitly returns same as default", () => {
+		writeFileSync(join(testDir, "source.md"), SOURCE_MD_CONTENT);
 		const defaultOutput = execSync(
 			`node "${CLI_PATH}" extract header "${join(testDir, "source.md")}" "Overview" --scope "${testDir}"`,
 			{ encoding: "utf8" },
@@ -72,6 +73,7 @@ describe("extract header --format flag", () => {
 	});
 
 	it("markdown content matches what JSON extractedContentBlocks[id].content would return", () => {
+		writeFileSync(join(testDir, "source.md"), SOURCE_MD_CONTENT);
 		const jsonOutput = execSync(
 			`node "${CLI_PATH}" extract header "${join(testDir, "source.md")}" "Overview" --scope "${testDir}" --format json`,
 			{ encoding: "utf8" },

--- a/test/cli-integration/extract-links-session-cache.test.ts
+++ b/test/cli-integration/extract-links-session-cache.test.ts
@@ -6,6 +6,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const CLI_PATH = join(__dirname, "../../dist/jact.js");
 
+const SOURCE_MD_CONTENT =
+	"# Source\n\nSee [[target.md#Section One|Section One]] for details.\n";
+const TARGET_MD_CONTENT =
+	"# Target\n\n## Section One\n\nThis is section one content.\n";
+
+function writeFixtures(testDir: string): void {
+	writeFileSync(join(testDir, "source.md"), SOURCE_MD_CONTENT);
+	writeFileSync(join(testDir, "target.md"), TARGET_MD_CONTENT);
+}
+
 describe("extract links --session (cache integration)", () => {
 	let testDir: string;
 
@@ -15,18 +25,6 @@ describe("extract links --session (cache integration)", () => {
 			`session-cache-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 		);
 		mkdirSync(testDir, { recursive: true });
-
-		// Create source markdown with a citation (wiki links require |displayText)
-		writeFileSync(
-			join(testDir, "source.md"),
-			"# Source\n\nSee [[target.md#Section One|Section One]] for details.\n",
-		);
-
-		// Create target markdown with the referenced section
-		writeFileSync(
-			join(testDir, "target.md"),
-			"# Target\n\n## Section One\n\nThis is section one content.\n",
-		);
 	});
 
 	afterEach(() => {
@@ -34,6 +32,7 @@ describe("extract links --session (cache integration)", () => {
 	});
 
 	it("first call with --session produces JSON output (cache miss)", () => {
+		writeFixtures(testDir);
 		const sourcePath = join(testDir, "source.md");
 		const output = execSync(
 			`node "${CLI_PATH}" extract links "${sourcePath}" --scope "${testDir}" --session test-session-1 --verbose`,
@@ -46,6 +45,7 @@ describe("extract links --session (cache integration)", () => {
 	});
 
 	it("second call with same --session produces no output (cache hit)", () => {
+		writeFixtures(testDir);
 		const sourcePath = join(testDir, "source.md");
 
 		// First call — cache miss
@@ -64,6 +64,7 @@ describe("extract links --session (cache integration)", () => {
 	});
 
 	it("no-links file with --session does not write cache (allows retry)", () => {
+		writeFileSync(join(testDir, "target.md"), TARGET_MD_CONTENT);
 		// Create a file with no extractable links
 		const noLinksPath = join(testDir, "no-links.md");
 		writeFileSync(


### PR DESCRIPTION
## Summary

- Audited all 40 test files for BDD/AAA style violations per Testing Principles §Test Authoring Style
- **Nesting depth:** No violations found — all `describe` blocks are at ≤3 levels
- **beforeEach input construction:** 3 files had `writeFileSync` calls constructing test fixture files inside `beforeEach`

## Changes

Moved `writeFileSync` calls from `beforeEach` into each test body and extracted fixture content as module-level constants:

- `test/cache/checkExtractCache.test.ts` — extracted `TEST_FILE_CONTENT` constant; `writeFileSync` moved into each of 4 tests
- `test/cli-integration/extract-header-format.test.ts` — extracted `SOURCE_MD_CONTENT` constant; `writeFileSync` moved into each of 4 tests
- `test/cli-integration/extract-links-session-cache.test.ts` — extracted `SOURCE_MD_CONTENT`/`TARGET_MD_CONTENT` constants and `writeFixtures()` helper; file writes moved into each test

`beforeEach` in all 3 files now performs lifecycle only (create tmpdir).

## Acceptance Criteria

- [x] Grep for nesting violations (>3 levels) — none found
- [x] Grep for `beforeEach` blocks constructing test inputs — 3 files found and fixed
- [x] All 12 tests in modified files pass after fix

## Test plan

- [x] `npx vitest run test/cache/checkExtractCache.test.ts test/cli-integration/extract-header-format.test.ts test/cli-integration/extract-links-session-cache.test.ts` — 12/12 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)